### PR TITLE
Custom linter configs tmp

### DIFF
--- a/app/models/linter_config_file.rb
+++ b/app/models/linter_config_file.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# A config file for a particular linter, e.g. .eslintrc or .rubocop.yml
+# Can be created from a full filepath or a content blob
+# access #path or #content when using in linters
+class LinterConfigFile
+  attr_reader :path
+
+  def initialize(path: nil, content: nil)
+    @path = path
+    @content = content
+    @path = create_temp_file(@content) if @content && !@path
+  end
+
+  def self.from_path(file_path)
+    LinterConfigFile.new(path: file_path)
+  end
+
+  def self.from_content(content)
+    LinterConfigFile.new(content: content)
+  end
+
+  def create_temp_file(content)
+    Tempfile.open('linter_config') do |file|
+      # keep a reference so the file does not get GC'd until this instance is gone
+      @tempfile = file
+      file.write(content)
+      file.path
+    end
+  end
+
+  def content
+    @content ||= File.read(@path)
+  end
+end

--- a/app/models/linter_config_file.rb
+++ b/app/models/linter_config_file.rb
@@ -4,12 +4,10 @@
 # Can be created from a full filepath or a content blob
 # access #path or #content when using in linters
 class LinterConfigFile
-  attr_reader :path
-
   def initialize(path: nil, content: nil)
+    raise ArgumentError, 'path or content must be provided' unless path || content
     @path = path
     @content = content
-    @path = create_temp_file(@content) if @content && !@path
   end
 
   def self.from_path(file_path)
@@ -20,6 +18,14 @@ class LinterConfigFile
     LinterConfigFile.new(content: content)
   end
 
+  def content
+    @content ||= File.read(@path)
+  end
+
+  def path
+    @path ||= create_temp_file(@content)
+  end
+
   def create_temp_file(content)
     Tempfile.open('linter_config') do |file|
       # keep a reference so the file does not get GC'd until this instance is gone
@@ -27,9 +33,5 @@ class LinterConfigFile
       file.write(content)
       file.path
     end
-  end
-
-  def content
-    @content ||= File.read(@path)
   end
 end

--- a/app/models/linters/base.rb
+++ b/app/models/linters/base.rb
@@ -1,15 +1,21 @@
-require_relative '../linters'
-
 module Linters
   # Defines the default relationship between the run_and_filter, run and
   # filter_messages methods of linters (i.e. don't filter any lints)
   class Base
+    def initialize(linter_config)
+      @linter_config = linter_config
+    end
+
     def run_and_filter(file)
       filter_messages(run(file), file)
     end
 
     def filter_messages(lints, _file)
       lints
+    end
+
+    def self.config_filename
+      nil
     end
   end
 end

--- a/app/models/linters/base.rb
+++ b/app/models/linters/base.rb
@@ -19,3 +19,6 @@ module Linters
     end
   end
 end
+
+require_relative './js_linter'
+require_relative '../linters'

--- a/app/models/linters/base.rb
+++ b/app/models/linters/base.rb
@@ -2,7 +2,7 @@ module Linters
   # Defines the default relationship between the run_and_filter, run and
   # filter_messages methods of linters (i.e. don't filter any lints)
   class Base
-    def initialize(linter_config)
+    def initialize(linter_config = nil)
       @linter_config = linter_config
     end
 

--- a/app/models/linters/coffee_lint.rb
+++ b/app/models/linters/coffee_lint.rb
@@ -1,13 +1,15 @@
 module Linters
   class CoffeeLint < Linters::JSLinter
-    CONFIG_PATH = Rails.root.join('coffeelint.json')
+    def self.config_path
+      Rails.root.join('coffeelint.json')
+    end
 
     def linter_name
       'CoffeeLint'
     end
 
     def config_contents
-      File.open(CONFIG_PATH) { |f| f.read }
+      File.open(self.class.config_path, &:read)
     end
 
     def linter_config

--- a/app/models/linters/es_lint.rb
+++ b/app/models/linters/es_lint.rb
@@ -25,13 +25,19 @@ module Linters
     end
 
     def cmd(file)
+      config = @linter_config ? ('-c ' + @linter_config.path) : ''
       <<-CMD.squish
         node_modules/eslint/bin/eslint.js
         -f json
         --stdin
         --stdin-filename #{file.path}
+        #{config}
         2>&1
       CMD
+    end
+
+    def self.config_filename
+      '.eslintrc'
     end
   end
 end

--- a/app/models/linters/js_linter.rb
+++ b/app/models/linters/js_linter.rb
@@ -1,19 +1,24 @@
 # An abstract linter that invokes a linter function written in JS using ExecJS
 module Linters
   class JSLinter < Linters::Base
-    SHIM_JS = Rails.root.join('src', 'envshim.js')
-    LINTER_JS = Rails.root.join('build', 'linters.js')
-
     def self.env
-      File.open(SHIM_JS) { |f| f.read }
+      File.open(shim_js, &:read)
     end
 
     def self.linters_source
-      @_linters_source ||= File.open(LINTER_JS) { |f| f.read }
+      @_linters_source ||= File.open(linter_js, &:read)
     end
 
     def self.context
       @_context ||= ExecJS.compile(env + linters_source)
+    end
+
+    def self.shim_js
+      Rails.root.join('src', 'envshim.js')
+    end
+
+    def self.linter_js
+      Rails.root.join('build', 'linters.js')
     end
 
     def fn_call_src(fn, *arguments)

--- a/app/models/linters/rubo_cop.rb
+++ b/app/models/linters/rubo_cop.rb
@@ -1,7 +1,9 @@
 class Linters::RuboCop < Linters::Base
   def run(file)
     return [] if ignored_file?(file)
-    runner = RuboCop::Runner.new({}, RuboCop::ConfigStore.new)
+    config = RuboCop::ConfigStore.new
+    config.options_config = @linter_config.path if @linter_config
+    runner = RuboCop::Runner.new({}, config)
     processed_source = processed_source_for(file)
     offenses, _ = runner.send(:inspect_file, processed_source)
     offenses.map { |o| Violation.new(file: file, line: o.location.line, message: o.message, linter: Linters::RuboCop) }
@@ -18,6 +20,10 @@ class Linters::RuboCop < Linters::Base
 
   def processed_source_for(file)
     RuboCop::ProcessedSource.new(file.blob, 2.3, file.path)
+  end
+
+  def self.config_filename
+    '.rubocop.yml'
   end
 end
 

--- a/lib/lintron/cli.rb
+++ b/lib/lintron/cli.rb
@@ -54,9 +54,7 @@ module Lintron
     end
 
     def pr
-      pr = LocalPrAlike.from_branch(org_name, repo_name, base_branch)
-      pr.linter_configs = relevant_linter_configs(pr.files)
-      pr
+      LocalPrAlike.from_branch(org_name, repo_name, base_branch, repo_path)
     end
 
     def base_branch
@@ -128,26 +126,6 @@ module Lintron
         org: path_parts[-2],
         repo: path_parts[-1],
       }
-    end
-
-    # a hash of file_name => LinterConfigFile
-    # for all linter configs pertaining to this PRs list of changed source files (StubFiles)
-    def relevant_linter_configs(files)
-      extensions = files.map(&:extname).uniq
-      extensions.reduce({}) do |linter_configs, extension|
-        linter_configs.merge(linter_configs_for(extension))
-      end
-    end
-
-    def linter_configs_for(extension)
-      Linters.linter_configs_for(extension).reduce({}) do |linter_configs, config_filename|
-        full_path = File.join(repo_path, config_filename)
-        if File.exist?(full_path)
-          linter_configs.merge(config_filename => LinterConfigFile.from_path(full_path))
-        else
-          linter_configs
-        end
-      end
     end
   end
 end

--- a/spec/models/linter_config_file_spec.rb
+++ b/spec/models/linter_config_file_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LinterConfigFile do
+  describe '#initialize' do
+    it 'requires a path or file content' do
+      expect do
+        LinterConfigFile.new
+      end.to raise_error
+    end
+
+    it 'saves a tmp file once if needed' do
+      config = LinterConfigFile.from_content('File Content')
+      first_path = config.path
+      expect(File.read(config.path)).to eq 'File Content'
+      expect(config.path).to eq first_path
+    end
+
+    it 'reads and caches content from a local file' do
+      path = Tempfile.open('temp') do |file|
+        file.write('File Content')
+        file.path
+      end
+      config = LinterConfigFile.from_path(path)
+      content = config.content
+      expect(content).to eq 'File Content'
+      File.unlink(path)
+      expect(config.content).to eq 'File Content'
+    end
+  end
+end

--- a/spec/support/mocks/pull_requests.rb
+++ b/spec/support/mocks/pull_requests.rb
@@ -19,6 +19,10 @@ class MockPR
   def latest_commit
     OpenStruct.new sha: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
   end
+
+  def get_config_file(filename)
+    nil
+  end
 end
 
 class FixturePR < MockPR


### PR DESCRIPTION
The general API for custom configs is:
* Each linter specifies its config filename (e.g. `.eslintrc`) by overloading `config_filename`
* Each linter takes a `LinterConfigFile` as an optional constructor argument. `LinterConfigFile`'s `#path` and `#content` give access to whatever format the particular linter prefers
* In the course of linting, `Linters` asks the PR for the `LinterConfigFiles` it needs to feed those linter constructors, and the PR handles getting those from Github or the local repo.

In order for the repo's configs to be used in local mode, the CLI has to send them up to the lintron server along with the diffs. This required bringing in all of the linter classes to query them for their config filenames. Because this also loads up every linter, there were some issues with load order and missing dependencies, which is why there are lots of random changes with how things are required and used. Is there a better way to handle those?

NOTE: Github mode is broken right here, since those PRs don't answer to `get_config_file`.